### PR TITLE
updated language comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "bats" extension will be documented in this file.
 
+## [0.1.2] - 2018-07-02
+
+- Fixed comments characters for extension.
+
 ## [0.1.1] - 2018-06-05
 
 - Fix spellings issue and some fun in Readme.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,9 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//",
-        // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-        "blockComment": [ "/*", "*/" ]
+        "lineComment": "#",
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
I've updated the language comments for the .bats filetype. `.bats` is bash based, so comments are `#` and not `//` and `/*`.

I also updated the changelog to bump the version number a minor version. I've left edits enabled tho so you can do whatever you want with this.

Great extension though!