### PR TITLE
Update keywords for latest Bats version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # BATS (Bash Automated Testing System) for VSCode
 
 [![Current Version](https://img.shields.io/visual-studio-marketplace/v/jetmartin.bats.svg?color=emerald&label=Visual%20Studio%20Marketplace&logo=visual-studio-code&logoColor=blue&style=flat)
-![Install Count](https://img.shields.io/visual-studio-marketplace/i/jetmartin.bats.svg?color=emerald&style=flat) 
+![Install Count](https://img.shields.io/visual-studio-marketplace/i/jetmartin.bats.svg?color=emerald&style=flat)
 ![downloads Count](https://img.shields.io/visual-studio-marketplace/d/jetmartin.bats.svg?color=emerald&style=flat)][marketplace]
  [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/jetmartin/bats.svg?color=emerald&label=release&logoColor=white&logo=github&labelColor=grey)][github]
 [![license](https://img.shields.io/badge/license-MIT-brightgreen.svg)][MIT]
 
-This extension adds language support for the [Bats] (Bash Automated Testing System) testing framework to [VS Code][vscode].
+This extension adds language support for the [Bats] (Bash Automated Testing System) testing framework to [VS Code][vscode]. Updated for Bats [v1.5.0]
 
 ## ![tada][_tada] Features
 
@@ -182,6 +182,7 @@ This extension was inspired by [sublime-bats].
 <!-- Links -->
 
 [Bats]: <https://github.com/bats-core/bats-core>
+[v1.5.0]: <https://github.com/bats-core/bats-core/releases/tag/v1.5.0>
 [sBats]: <https://github.com/sstephenson/bats>
 [@sstephenson]: <https://github.com/sstephenson>
 [@bats-core]: <https://github.com/bats-core>

--- a/syntaxes/bats.extended.tmLanguage
+++ b/syntaxes/bats.extended.tmLanguage
@@ -17,7 +17,7 @@
             <!-- bats -->
             <dict>
                 <key>match</key>
-                <string>\b(run|load|skip)\b</string>
+                <string>\b(run|load|skip|setup|teardown|setup_file|teardown_file)\b</string>
                 <key>name</key>
                 <string>support.function.bats.builtin</string>
             </dict>

--- a/syntaxes/bats.variables.tmLanguage
+++ b/syntaxes/bats.variables.tmLanguage
@@ -10,13 +10,13 @@
         <array>
             <dict>
                 <key>match</key>
-                <string>\$(output|status|lines)\b</string>
+                <string>\$(output|status|lines|stderr|stderr_lines)\b</string>
                 <key>name</key>
                 <string>support.variable.bats</string>
             </dict>
             <dict>
                 <key>match</key>
-                <string>\$\{#?(output|status|lines)\b</string>
+                <string>\$\{#?(output|status|lines|stderr|stderr_lines)\b</string>
                 <key>captures</key>
                 <dict>
                     <key>1</key>

--- a/test/test.bats
+++ b/test/test.bats
@@ -1,5 +1,13 @@
 #!/usr/bin/env bats
 
+setup_file() {
+  :
+}
+
+teardown_file() {
+  :
+}
+
 ##
 # Simple test file for syntax coloration check on VSCode.
 #
@@ -99,6 +107,12 @@ load test_helper
 @test 'some test' {
   run refute false
 }
+
+##
+# bats-assert
+#
+# assert assert_equal assert_success assert_failure assert_output
+# refute_output assert_line refute_line refute
 
 ##
 # bats-mock

--- a/test/test.bats
+++ b/test/test.bats
@@ -109,12 +109,6 @@ load test_helper
 }
 
 ##
-# bats-assert
-#
-# assert assert_equal assert_success assert_failure assert_output
-# refute_output assert_line refute_line refute
-
-##
 # bats-mock
 #
 # stub unstub


### PR DESCRIPTION
This adds `setup_file` `teardown_file`, `setup`, and `teardown`. (Although these are functions declarations, would they still go under the place they are now?)

The next version of Bats will also have `stderr` and `stderr_lines` (see docs at [HEAD](https://github.com/bats-core/bats-core/blob/master/docs/source/writing-tests.md)), which I have added