### PR TITLE
Add support for bats-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BATS (Bash Automated Testing System) for VSCode
 
 [![Current Version](https://img.shields.io/visual-studio-marketplace/v/jetmartin.bats.svg?color=emerald&label=Visual%20Studio%20Marketplace&logo=visual-studio-code&logoColor=blue&style=flat)
-![Install Count](https://img.shields.io/visual-studio-marketplace/i/jetmartin.bats.svg?color=emerald&style=flat) 
+![Install Count](https://img.shields.io/visual-studio-marketplace/i/jetmartin.bats.svg?color=emerald&style=flat)
 ![downloads Count](https://img.shields.io/visual-studio-marketplace/d/jetmartin.bats.svg?color=emerald&style=flat)][marketplace]
  [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/jetmartin/bats.svg?color=emerald&label=release&logoColor=white&logo=github&labelColor=grey)][github]
 [![license](https://img.shields.io/badge/license-MIT-brightgreen.svg)][MIT]
@@ -42,7 +42,7 @@ Project | version | code snippets | syntax highlighting
 <https://github.com/bats-core/bats-core>      | [![bats-core project][badge-core]][bats-core-l]          | ![Y][_white_check_mark] | ![Y][_white_check_mark]
 <https://github.com/jasonkarns/bats-assert-1> | [![bats-assert project][badge-assert]][bats-assert-l]    | ![Y][_white_check_mark] | ![Y][_white_check_mark]
 <https://github.com/jasonkarns/bats-support>  | [![bats-support project][badge-support]][bats-support-l] | ![N][_negative_squared_cross_mark] | ![Y][_white_check_mark]
-<https://github.com/ztombol/bats-file>        | [![bats-file project][badge-file]][bats-file-l]          | ![N][_negative_squared_cross_mark] | ![N][_negative_squared_cross_mark]
+<https://github.com/ztombol/bats-file>        | [![bats-file project][badge-file]][bats-file-l]          | ![N][_negative_squared_cross_mark] | ![Y][_white_check_mark]
 <https://github.com/lox/bats-mock>            | [![bats-mock project][badge-mock]][bats-mock-l]          | ![N][_negative_squared_cross_mark] | ![Y][_white_check_mark]
 
 ## ![scissors][_scissors] Snippets

--- a/syntaxes/bats.extended.tmLanguage
+++ b/syntaxes/bats.extended.tmLanguage
@@ -42,6 +42,13 @@
                 <key>name</key>
                 <string>support.function.bats.assertions</string>
             </dict>
+            <!-- bats-file -->
+            <dict>
+                <key>match</key>
+                <string>\b(assert_((((file|dir|link|block|character|socket|fifo)_)?(not_)?exist)|(file_((not_)?(executable|owner|group_id_set|user_id_set|empty)))|(not_)?file_permission|file_size_equals|size_(not_)?zero|(no_)?sticky_bit|file_contains|(not_)?symlink_to))\b</string>
+                <key>name</key>
+                <string>support.function.bats.assertions</string>
+            </dict>
         </array>
     </dict>
 </plist>

--- a/test/test.bats
+++ b/test/test.bats
@@ -100,6 +100,51 @@ load test_helper
   run refute false
 }
 
+# bats-file
+#
+# assert_exist assert_not_exist
+@test 'some test' {
+  assert_exist ''
+  assert_not_exist ''
+  assert_file_exist
+  assert_file_not_exist
+  assert_dir_exist
+  assert_dir_not_exist
+  assert_link_exist
+  assert_link_not_exist
+  assert_block_exist
+  assert_block_not_exist
+  assert_character_exist
+  assert_character_not_exist
+  assert_socket_exist
+  assert_socket_not_exist
+  assert_fifo_exist
+  assert_fifo_not_exist
+  assert_file_executable
+  assert_file_not_executable
+  assert_file_owner
+  assert_file_not_owner
+  assert_file_permission
+  assert_not_file_permission
+  assert_file_not_permission # not highlighted
+  assert_file_size_equals
+  assert_size_zero
+  assert_size_not_zero
+  assert_file_group_id_set
+  assert_file_not_group_id_set
+  assert_file_user_id_set
+  assert_file_not_user_id_set
+  assert_sticky_bit
+  assert_no_sticky_bit
+  assert_not_sticky_bit # not highlighted
+  assert_file_empty
+  assert_file_not_empty
+  assert_file_contains
+  # assert_file_not_contains deprecated
+  assert_symlink_to
+  assert_not_symlink_to
+}
+
 ##
 # bats-mock
 #


### PR DESCRIPTION
Hai,

[bats-file](https://github.com/bats-core/bats-file) contains useful functions for testing particular characteristics of files, and noticed this extension didn't support highlighting aspects of it. I think it would useful adding support for those functions. Thoughts?

Edwin