### PR TITLE
Add missing keywords: assert_not_equal, bats_load_library

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,16 @@ Type `BATS:*snippet*` to use snippets.
 
 [![bats-core snippets][badge-core]][bats-core-l]
 
-- [x] **BATS:env**      : shebang.
-- [x] **BATS:setup**    : Setup function.
-- [x] **BATS:teardown** : Teardown function.
-- [x] **BATS:load**     : Load common code.
-- [x] **BATS:test**     : Test case.
-- [x] **BATS:status**   : Test status code.
-- [x] **BATS:output**   : Test output.
-- [x] **BATS:line**     : Test line output.
-- [x] **BATS:skip**     : Skip test.
+- [x] **BATS:env**               : shebang.
+- [x] **BATS:setup**             : Setup function.
+- [x] **BATS:teardown**          : Teardown function.
+- [x] **BATS:load**              : Load common code.
+- [x] **BATS:bats_load_library** : Load system-wide libraries.
+- [x] **BATS:test**              : Test case.
+- [x] **BATS:status**            : Test status code.
+- [x] **BATS:output**            : Test output.
+- [x] **BATS:line**              : Test line output.
+- [x] **BATS:skip**              : Skip test.
 
 [![bats-assert snippets][badge-assert]][bats-assert-l]
 
@@ -77,6 +78,7 @@ Type `BATS:*snippet*` to use snippets.
 - [x] **BATS:assert_success**
 - [x] **BATS:assert_failure**
 - [x] **BATS:assert_equal**
+- [x] **BATS:assert_not_equal**
 - [x] **BATS:refute**
 - [x] **BATS:refute_output**
 - [x] **BATS:refute_line**

--- a/snippets/bats-assert.json
+++ b/snippets/bats-assert.json
@@ -79,6 +79,7 @@
         ],
         "description": "@test assert_success: Fail if $status is not 0."
     },
+
     "@test assert_equal: Fail if the two parameters, actual and expected value respectively, do not equal.": {
         "prefix": "BATS:assert_equal <actual> <expected>",
         "body": [
@@ -92,6 +93,21 @@
             "}\n\n"
         ],
         "description": "@test assert_equal: Fail if the actual and expected values are not equal."
+    },
+
+    "@test assert_not_equal: Fail if the two parameters, actual and expected value respectively, are equal.": {
+        "prefix": "BATS:assert_not_equal <actual> <expected>",
+        "body": [
+            "@test '${1:describe test for assert_not_equal()}' {",
+            "\tassert_not_equal '${2:have}' '${3:want}'\n",
+            "\t# On failure, the expected and actual values are displayed.",
+            "\t# -- values should not be equal --",
+            "\t# expected : want",
+            "\t# actual   : have",
+            "\t# --",
+            "}\n\n"
+        ],
+        "description": "@test assert_not_equal: Fail if the actual and expected values are equal."
     },
 
     "@test assert_failure (status): Fail if $status is 0.": {
@@ -475,4 +491,3 @@
         "description": "@test refute_line (regexp): The assertion fails if the extended regular expression matches the line being tested. Regular expression matching can be enabled with the --regexp option (-e for short). This option and partial matching (--partial or -p) are mutually exclusive. An error is displayed when used simultaneously."
     },
 }
-

--- a/syntaxes/bats.extended.tmLanguage
+++ b/syntaxes/bats.extended.tmLanguage
@@ -17,7 +17,7 @@
             <!-- bats -->
             <dict>
                 <key>match</key>
-                <string>\b(run|load|skip|setup|teardown|setup_file|teardown_file)\b</string>
+                <string>\b(run|load|bats_load_library|skip|setup|teardown|setup_file|teardown_file)\b</string>
                 <key>name</key>
                 <string>support.function.bats.builtin</string>
             </dict>
@@ -31,7 +31,7 @@
             <!-- bats-assert -->
             <dict>
                 <key>match</key>
-                <string>\b(assert|refute|assert_(equal|success|failure|output|line)|refute_(output|line))\b</string>
+                <string>\b(assert|refute|assert_(equal|not_equal|success|failure|output|line)|refute_(output|line))\b</string>
                 <key>name</key>
                 <string>support.function.bats.assertions</string>
             </dict>

--- a/test/test.bats
+++ b/test/test.bats
@@ -15,10 +15,11 @@ teardown_file() {
 ##
 # bats-core
 #
-# load run skip
+# load bats_load_library run skip
 # output status lines
 
 load test_helper
+bats_load_library test_helper
 @test 'some test' {
   run foo
   skip echo "${var}"
@@ -83,14 +84,17 @@ load test_helper
 ##
 # bats-assert
 #
-# assert assert_equal assert_success assert_failure assert_output
-# refute_output assert_line refute_line refute
+# assert assert_equal assert_not_equal assert_success assert_failure
+# assert_output refute_output assert_line refute_line refute
 
 @test 'some test' {
   run assert true
 }
 @test 'some test' {
   run assert_equal 'a' 'a'
+}
+@test 'some test' {
+  run assert_not_equal 'a' 'b'
 }
 @test 'some test' {
   run assert_success


### PR DESCRIPTION
I noticed that `assert_not_equal` was missing from `support.function.bats.assertions` so I added it. I looked for any other missing keywords and saw that `bats_load_library` was also not included, so I added that as well. Readme & tests were updated for both. I do not understand the purpose of `snippets` so I left them alone; please let me know if they need to be updated, too.