### PR TITLE
Expand variable highlights to support Bash parameter expansion

### DIFF
--- a/syntaxes/bats.variables.tmLanguage
+++ b/syntaxes/bats.variables.tmLanguage
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
     <dict>
@@ -11,18 +11,42 @@
             <dict>
                 <key>match</key>
                 <string>\$(output|status|lines|stderr|stderr_lines)\b</string>
-                <key>name</key>
-                <string>support.variable.bats</string>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>support.variable.bats</string>
+                    </dict>
+                </dict>
             </dict>
             <dict>
                 <key>match</key>
-                <string>\$BATS_(RUN_COMMAND|TEST_(FILENAME|DIRNAME|NAMES?|DESCRIPTION)|(SUITE_)?TEST_NUMBER|((RUN|FILE|SUITE|TEST)_)?TMPDIR|FILE_EXTENSION|VERSION)\b</string>
-                <key>name</key>
-                <string>support.variable.bats</string>
+                <string>\${#?(output|status|lines|stderr|stderr_lines)\b[^}]*}</string>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>support.variable.bats</string>
+                    </dict>
+                </dict>
             </dict>
             <dict>
                 <key>match</key>
-                <string>\$\{#?(output|status|lines|stderr|stderr_lines)\b</string>
+                <string>\$(BATS_(RUN_COMMAND|TEST_(FILENAME|DIRNAME|NAMES?|DESCRIPTION)|(SUITE_)?TEST_NUMBER|((RUN|FILE|SUITE|TEST)_)?TMPDIR|FILE_EXTENSION|VERSION))\b</string>
+                <key>captures</key>
+                <dict>
+                    <key>1</key>
+                    <dict>
+                        <key>name</key>
+                        <string>support.variable.bats</string>
+                    </dict>
+                </dict>
+            </dict>
+            <dict>
+                <key>match</key>
+                <string>\${#?(BATS_(RUN_COMMAND|TEST_(FILENAME|DIRNAME|NAMES?|DESCRIPTION)|(SUITE_)?TEST_NUMBER|((RUN|FILE|SUITE|TEST)_)?TMPDIR|FILE_EXTENSION|VERSION))\b[^}]*}</string>
                 <key>captures</key>
                 <dict>
                     <key>1</key>

--- a/test/test.bats
+++ b/test/test.bats
@@ -25,13 +25,14 @@ bats_load_library test_helper
   skip echo "${var}"
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "${some_var}" ]
-  [ "${lines[@]}" = 1 ]
+  [ "${#lines[@]}" = 1 ]
   [ "$output" == 'some value' ]
 }
 # using --separate-stderr
 @test 'some other test' {
   run foo
-  [ "${stderr_lines[@]}" = 1 ]
+  [ "${stderr_lines[0]}" = "${other_var}" ]
+  [ "${#stderr_lines[@]}" = 1 ]
   [ "$stderr" == 'some value' ]
 }
 
@@ -179,7 +180,7 @@ bats_load_library test_helper
   assert_fifo_exists
   assert_fifo_not_exists
   assert_sticky_bit
-  assert_no_sticky_bit	
+  assert_no_sticky_bit
 }
 ##
 # bats-file
@@ -231,3 +232,59 @@ $BATS_SUITE_TMPDIR
 $BATS_FILE_TMPDIR
 $BATS_TEST_TMPDIR
 $BATS_VERSION
+
+# exercise the syntax color in various ways on a Bats variable name
+
+$BATS_TEST_DIRNAME
+${BATS_TEST_DIRNAME}
+${BATS_TEST_DIRNAME##*/}
+${BATS_TEST_DIRNAME%/*}
+${BATS_TEST_DIRNAME:1:2}
+${#BATS_TEST_DIRNAME}
+$BATS_TEST_DIRNAME/file
+${BATS_TEST_DIRNAME}/file
+var=$BATS_TEST_DIRNAME
+var=${BATS_TEST_DIRNAME}
+var=$BATS_TEST_DIRNAME/file
+var=${BATS_TEST_DIRNAME}/file
+"$BATS_TEST_DIRNAME"
+"${BATS_TEST_DIRNAME}"
+"$BATS_TEST_DIRNAME/file"
+"${BATS_TEST_DIRNAME}/file"
+var="$BATS_TEST_DIRNAME"
+var="${BATS_TEST_DIRNAME}"
+var="$BATS_TEST_DIRNAME/file"
+var="${BATS_TEST_DIRNAME}/file"
+
+# exercise the syntax color in various ways on a Bats output variable name
+
+$stderr_lines
+${stderr_lines}
+${stderr_lines[3]}
+${stderr_lines##*/}
+${stderr_lines%/*}
+${stderr_lines:1:2}
+${#stderr_lines[@]}
+$stderr_lines-composite
+${stderr_lines}composite
+var=$stderr_lines
+var=${stderr_lines}
+var=${stderr_lines[3]}
+var=${#stderr_lines[@]}
+var=$stderr_lines-composite
+var=${stderr_lines}composite
+var=${stderr_lines[3]}composite
+"$stderr_lines"
+"${stderr_lines}"
+"${stderr_lines[3]}"
+"${#stderr_lines[@]}"
+"$stderr_lines-composite"
+"${stderr_lines}composite"
+"${stderr_lines[3]}composite"
+var="$stderr_lines"
+var="${stderr_lines}"
+var="${stderr_lines[3]}"
+var="${#stderr_lines[@]}"
+var="$stderr_lines-composite"
+var="${stderr_lines}composite"
+var="${stderr_lines[3]}composite"


### PR DESCRIPTION
* Add support for all of the existing Bats variables in ${var} form.
* Add tests for each of the matches using various real-world examples.
* Fix some existing tests


Hi

I prefer to use the `${var}` form of variables in Bash. However, the current matches for this extension do not support that form except for counting variables for output variables, like `${#lines[@]}`.

This PR is some trivial work to help support both the `$var` and `${var}` forms in Bats files, plus a little cleanup of the match file.

This does introduce an intentional regression. Previously, the `$` would be included in the `support.variable.bats` scope, and thus be given the same foreground style as the variable name. However, when expanding the matches to include the `${var}` style, this lead to inconsistent styling of the braces, even when they were captured and given the `support.variable.bats` scope.

Similarly, I could find no way to collapse the matches down so the file had just 1 entry per variable list, without inconsistent styling of the braces. In this case, that would be open brace `{` red and closed brace `}` yellow on the same `${var}`, somehow.

I have also updated the `test.bats` file, where I've added a pretty extensive "workout" of the syntax coloring. I'm using the color customizations recommended in the README.md file. Since the visual "tests" in this file were pass-only, I've kept with that convention. However, I did some failing visual tests of my own and they all failed properly.

Finally, there were a few tests that seemed to be missing or incorrect, and I corrected them.
